### PR TITLE
Adds support for npins

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This is a fairly straightforward setup for making a NixOS system configuration s
 
 This means:
 - `nix-channel` is disabled
-- Nixpkgs is managed with [niv](https://github.com/nmattia/niv) [^1]
+- Nixpkgs is managed with [niv](https://github.com/nmattia/niv) or [npins](https://github.com/andir/npins)  [^1]
 - The same Nixpkgs is used for the system and all Nix commands
 - This includes the Nixpkgs version, config and overlays
 
-[^1]: Yes niv is a third-party tool, but it's essentially just a nice wrapper around `nix-prefetch-url` and co.
+[^1]: Yes niv and npins are third-party tools, but they're essentially just nice wrappers around `nix-prefetch-url` and co.
 
 ## Usage
 
@@ -31,10 +31,17 @@ We're assuming that you just installed NixOS by going through the [official inst
      ```
      nixos-generate-config --dir .
      ```
-3. Pin Nixpkgs to the [latest stable version](https://nixos.org/manual/nixos/stable/release-notes) using [niv](https://github.com/nmattia/niv):
+3. Pin Nixpkgs to the [latest stable version](https://nixos.org/manual/nixos/stable/release-notes) using [niv](https://github.com/nmattia/niv) or [npins](https://github.com/andir/npins):
    ```
    nix-shell -p niv --run \
      'niv init --nixpkgs NixOS/nixpkgs --nixpkgs-branch nixos-23.11'
+   ```
+   or
+   ```
+   nix-shell -p npins
+     npins init --bare
+     npins add --name nixpkgs github nixos nixpkgs --branch nixos-23.11
+     exit
    ```
 4. Remove all stateful channels:
    ```
@@ -54,9 +61,18 @@ Here are some changes you can make:
   ```
   niv update nixpkgs
   ```
+  or
+  ```
+  npins update nixpkgs
+  ```
 - Upgrade to a newer release:
   ```
   niv update nixpkgs --branch nixos-23.11
+  ```
+  or
+
+  ```
+  npins add --name nixpkgs github nixos nixpkgs --branch nixos-24.05
   ```
 - Change the Nixpkgs config by editing `nixpkgs/config.nix`
 - Add Nixpkgs overlays to `nixpkgs/overlays.nix`

--- a/nixpkgs/path.nix
+++ b/nixpkgs/path.nix
@@ -1,2 +1,12 @@
 # The Nixpkgs path to use
-(import ../nix/sources.nix).nixpkgs.outPath
+let
+  nivPath = ../nix/sources.nix;
+  npinsPath = ../npins/default.nix;
+  pinPath = if builtins.pathExists nivPath then
+              nivPath
+            else if builtins.pathExists npinsPath then
+              npinsPath
+            else
+              abort "Did you forget `niv init` or `npins init`";
+in
+  (import pinPath).nixpkgs.outPath

--- a/root.nix
+++ b/root.nix
@@ -5,8 +5,8 @@
   ];
 
   environment.systemPackages = with pkgs; [
-    # We're using niv to manage the systems Nixpkgs version, install it globally for ease
-    niv
+    # We're using niv or npins to manage the systems Nixpkgs version, install them globally for ease
+    niv npins
   ];
 
   # Use the Nixpkgs config and overlays from the local files for this NixOS build


### PR DESCRIPTION
This PR adds support for [npins](https://github.com/andir/npins), which is an alternative to [niv](https://github.com/nmattia/niv).

Test that the modifications do not break `niv`:

```shell
$ niv init
Initializing
  Creating nix/sources.nix
  Creating nix/sources.json
  Using known 'nixpkgs' ...
  Adding package nixpkgs
    Writing new sources file
  Done: Adding package nixpkgs
Done: Initializing
$ cd nixpkgs
$ nix repl
Welcome to Nix 2.18.4. Type :? for help.
nix-repl> import ./path.nix
"/nix/store/pp307nbzkgsd6393zl2i9j4j86z5nz9b-nixpkgs-src"
nix-repl> :q
$ cd ..
$ rm -rf nix
```
Now test that it works for `npins`:

```shell
$ npins init
[INFO ] Welcome to npins!
[INFO ] Writing default.nix
[INFO ] Writing initial sources.json with nixpkgs entry (need to fetch latest commit first)
[INFO ] Successfully written initial files to 'npins'.
$ cd nixpkgs
$ nix repl
Welcome to Nix 2.18.4. Type :? for help.
nix-repl> import ./path.nix
"/nix/store/9dk9hzlmk3z2qxmz9d14xikan150pwxj-source"
nix-repl> :q
$ cd ..
$ rm -rf npins
```

What happens if both are initialized? Give priority to `niv` so existing uses do not break:

```shell
$ niv init
Initializing
  Creating nix/sources.nix
  Creating nix/sources.json
  Using known 'nixpkgs' ...
  Adding package nixpkgs
    Writing new sources file
  Done: Adding package nixpkgs
Done: Initializing
$ npins init
[INFO ] Welcome to npins!
[INFO ] Creating `npins` directory
[INFO ] Writing default.nix
[INFO ] Writing initial sources.json with nixpkgs entry (need to fetch latest commit first)
[INFO ] Successfully written initial files to 'npins'.
$ cd nixpkgs
$ nix repl
Welcome to Nix 2.18.4. Type :? for help.
nix-repl> import ./path.nix
"/nix/store/pp307nbzkgsd6393zl2i9j4j86z5nz9b-nixpkgs-src"
nix-repl> :q
$ cd ..
$ rm -rf nix npins
```

Complain if neither have been initialized:

```shell
$ cd nixpkgs
$ nix repl
Welcome to Nix 2.18.4. Type :? for help.
nix-repl> import ./path.nix
...
       error: evaluation aborted with the following error message: 'Did you forget `niv init` or `npins init`'
nix-repl> :q
$ cd ..
```

Looks like the modification works correctly.